### PR TITLE
Raise mix error if manager is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Raise an error if a generator is run before ecsx.setup
+
 ## v0.3.1 (2023-01-12)
 
 Added ECSx.ClientEvents: ephemeral components created by client processes to communicate user input/interaction with the ECSx backend  

--- a/lib/ecsx/client_events.ex
+++ b/lib/ecsx/client_events.ex
@@ -45,11 +45,11 @@ defmodule ECSx.ClientEvents do
 
   ## Examples
 
-    # Simple event requiring no metadata
-    ECSx.ClientEvents.add(player_id, :spawn_player)
+      # Simple event requiring no metadata
+      ECSx.ClientEvents.add(player_id, :spawn_player)
 
-    # Event with metadata
-    ECSx.ClientEvents.add(player_id, {:send_message_to, recipient_id, message})
+      # Event with metadata
+      ECSx.ClientEvents.add(player_id, {:send_message_to, recipient_id, message})
 
   """
   @spec add(id(), any()) :: :ok

--- a/lib/mix/tasks/ecsx.gen.component.ex
+++ b/lib/mix/tasks/ecsx.gen.component.ex
@@ -44,8 +44,8 @@ defmodule Mix.Tasks.Ecsx.Gen.Component do
   def run([component_type_name, value_type | opts]) do
     value_type = validate(value_type)
     {opts, _, _} = OptionParser.parse(opts, strict: [unique: :boolean])
-    create_component_file(component_type_name, value_type, opts)
     Helpers.inject_component_module_into_manager(component_type_name)
+    create_component_file(component_type_name, value_type, opts)
   end
 
   defp message_with_help(message) do

--- a/lib/mix/tasks/ecsx.gen.system.ex
+++ b/lib/mix/tasks/ecsx.gen.system.ex
@@ -28,8 +28,8 @@ defmodule Mix.Tasks.Ecsx.Gen.System do
   end
 
   def run([system_name | _] = _args) do
-    create_system_file(system_name)
     inject_system_module_into_manager(system_name)
+    create_system_file(system_name)
   end
 
   defp create_system_file(system_name) do
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Ecsx.Gen.System do
   end
 
   defp parse_manager(path) do
-    file = File.read!(path)
+    file = Helpers.read_manager_file!(path)
     [top, rest] = String.split(file, "def systems do", parts: 2)
     [list, bottom] = String.split(rest, "end", parts: 2)
 

--- a/lib/mix/tasks/ecsx.gen.tag.ex
+++ b/lib/mix/tasks/ecsx.gen.tag.ex
@@ -21,8 +21,8 @@ defmodule Mix.Tasks.Ecsx.Gen.Tag do
   end
 
   def run([tag_name | _]) do
-    create_component_file(tag_name)
     Helpers.inject_component_module_into_manager(tag_name)
+    create_component_file(tag_name)
   end
 
   defp message_with_help(message) do

--- a/lib/mix/tasks/ecsx/helpers.ex
+++ b/lib/mix/tasks/ecsx/helpers.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.ECSx.Helpers do
   end
 
   defp parse_manager_components(path) do
-    file = File.read!(path)
+    file = read_manager_file!(path)
     [top, rest] = String.split(file, "def components do", parts: 2)
     [list, bottom] = String.split(rest, "end", parts: 2)
 
@@ -70,5 +70,12 @@ defmodule Mix.Tasks.ECSx.Helpers do
     ["[" | rest] = String.graphemes(list_as_string)
 
     ["[\n" | rest]
+  end
+
+  def read_manager_file!(path) do
+    case File.read(path) do
+      {:ok, file} -> file
+      {:error, :enoent} -> Mix.raise("ECSx manager missing - please run `mix ecsx.setup` first!")
+    end
   end
 end


### PR DESCRIPTION
Update generators:
* Wrap `File.read/1` to raise when manager is not found
* Attempt manager injection before file creation, so raising does not leave the user in a halfway state