### PR TITLE
Start ECSx.ClientEvents automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Adding ECSx.ClientEvents to the supervision tree is no longer required
+
 ## v0.3.1 (2023-01-12)
 
 Added ECSx.ClientEvents: ephemeral components created by client processes to communicate user input/interaction with the ECSx backend  

--- a/guides/web_frontend_liveview.md
+++ b/guides/web_frontend_liveview.md
@@ -14,28 +14,19 @@ Phoenix comes with an [AuthN generator](https://hexdocs.pm/phoenix/Mix.Tasks.Phx
 
 This will expect players to register an email and password, which will be used to log in.  A unique ID will also be created for each player upon registration, allowing us to begin thinking of players as entities.  However, we can't just take the player input and start creating components with it - only systems can create components.  Instead, we'll use a special component type provided for this purpose: `ECSx.ClientEvents`.
 
-## Adding ECSx.ClientEvents
-
-First head into `application.ex` and add it to your supervision tree:
-
-```elixir
-def start(_type, _args) do
-  children = [
-    ...
-    # You can add this anywhere in the list, as long as it's before `MyAppWeb.Endpoint`.
-    ECSx.ClientEvents,
-    ...
-    MyAppWeb.Endpoint
-  ]
-
-  opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-  Supervisor.start_link(children, opts)
-end
-```
-
 ## Client Input via LiveView
 
-Then we'll create `/lib/my_app_web/game_live.ex` and put it to use:
+First consider the goals for our frontend:
+
+  * Authenticate the player and hold player ID
+  * Spawn the player's ship upon connection (writes components)
+  * Hold the coordinates for the player's ship
+  * Hold the coordinates for enemy ships
+  * Validate user input to move the ship (writes components)
+
+When we need to write components, `ECSx.ClientEvents` will be our line of communication from the frontend to the backend.  
+
+Let's create `/lib/my_app_web/game_live.ex` and put it to use:
 
 ```elixir
 defmodule MyAppWeb.GameLive do

--- a/lib/ecsx.ex
+++ b/lib/ecsx.ex
@@ -12,4 +12,14 @@ defmodule ECSx do
   A single GenServer manages the ETS tables to ensure strict serializability and customize
   the run order for Systems.
   """
+  use Application
+
+  @doc false
+  def start(_type, _args) do
+    children = [
+      ECSx.ClientEvents
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: ECSx.Supervisor)
+  end
 end

--- a/lib/ecsx/client_events.ex
+++ b/lib/ecsx/client_events.ex
@@ -2,16 +2,6 @@ defmodule ECSx.ClientEvents do
   @moduledoc """
   A store to which clients can write, for communication with the ECSx backend.
 
-  ## Usage
-
-  To use ClientEvents, it must be added to your application's supervision tree:
-
-      children = [
-        ...
-        ECSx.ClientEvents
-        ...
-      ]
-
   Events are created from the client process by calling `add/2`, then retrieved by the handler
   system using `get_and_clear/0`.  You will be required to create the handler system yourself -
   see the [tutorial project](web_frontend_liveview.html#handling-client-events) for a detailed example.

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule ECSx.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {ECSx, []},
       extra_applications: [:logger, :eex, :mix]
     ]
   end


### PR DESCRIPTION
* Add `:mod` to our application to start a supervisor
* Supervisor will start ECSx.ClientEvents

This means users won't be asked to manually add the module to their supervision tree