### PR TITLE
Move server tick rate setting to application config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Adding ECSx.ClientEvents to the supervision tree is no longer required  
 Running a generator before ecsx.setup will now raise an error   
 Added telemetry events  
+Tick rate is now set in application config  
+Added ECSx.tick_rate/0 for reading the configured value  
 
 ## v0.3.1 (2023-01-12)
 

--- a/guides/tutorial/backend_basics.md
+++ b/guides/tutorial/backend_basics.md
@@ -79,7 +79,7 @@ end
 
 Now whenever a ship gains velocity, this system will update the position accordingly over time.  Keep in mind that the velocity is relative to the server's tick rate, which by default is 20.  This means the unit of measurement is "game units per 1/20th of a second".
 
-For example, if you want the speed to move from XPosition 0 to XPosition 100 in one second, you divide the distance 100 by the tick rate 20, to see that an XVelocity of 5 is appropriate.  The tick rate can be changed in `lib/ship/manager.ex`.
+For example, if you want the speed to move from XPosition 0 to XPosition 100 in one second, you divide the distance 100 by the tick rate 20, to see that an XVelocity of 5 is appropriate.  The tick rate can be changed in `config/config.ex`.
 
 ## Targeting & Attacking
 

--- a/lib/ecsx.ex
+++ b/lib/ecsx.ex
@@ -22,4 +22,18 @@ defmodule ECSx do
 
     Supervisor.start_link(children, strategy: :one_for_one, name: ECSx.Supervisor)
   end
+
+  @doc """
+  Returns the tick rate of the ECSx application.
+
+  This defaults to 20, and can be configured with
+
+  ```elixir
+  config :ecsx, tick_rate: 20
+  ```
+  """
+  @spec tick_rate() :: integer()
+  def tick_rate do
+    Application.get_env(:ecsx, :tick_rate, 20)
+  end
 end

--- a/lib/ecsx.ex
+++ b/lib/ecsx.ex
@@ -26,10 +26,10 @@ defmodule ECSx do
   @doc """
   Returns the tick rate of the ECSx application.
 
-  This defaults to 20, and can be configured with
+  This defaults to 20, and can be changed in your app configuration:
 
   ```elixir
-  config :ecsx, tick_rate: 20
+  config :ecsx, tick_rate: 15
   ```
   """
   @spec tick_rate() :: integer()

--- a/lib/ecsx/manager.ex
+++ b/lib/ecsx/manager.ex
@@ -7,14 +7,7 @@ defmodule ECSx.Manager do
     * starting up ETS tables for each Component Type, where the Components will be stored
     * prepopulating the game content into memory
     * keeping track of the Systems to run, and their run order
-    * configuring the tick rate for the application
     * running the Systems every tick
-
-  ## `:tick_rate` option
-
-  The `mix ecsx.setup` generator creates a Manager file with `:tick_rate` set to 20
-  (i.e. 20 ticks per second).  Feel free to change this number to fit the needs
-  of your application.
 
   ## `components/0` and `systems/0`
 
@@ -36,8 +29,6 @@ defmodule ECSx.Manager do
 
       import ECSx.Manager
 
-      @tick_rate opts[:tick_rate] || 20
-
       def start_link(_), do: ECSx.Manager.start_link(__MODULE__)
 
       def init(_) do
@@ -49,7 +40,8 @@ defmodule ECSx.Manager do
       end
 
       def handle_continue(:start_systems, max_tick) do
-        tick_interval = div(1000, @tick_rate)
+        tick_rate = ECSx.tick_rate()
+        tick_interval = div(1000, tick_rate)
         :timer.send_interval(tick_interval, :tick)
 
         {:noreply, {0, max_tick}}

--- a/priv/templates/manager.ex
+++ b/priv/templates/manager.ex
@@ -2,7 +2,7 @@ defmodule <%= app_name %>.Manager do
   @moduledoc """
   ECSx manager.
   """
-  use ECSx.Manager, tick_rate: 20
+  use ECSx.Manager
 
   setup do
     # Load your initial components

--- a/test/mix/tasks/ecsx.gen.component_test.exs
+++ b/test/mix/tasks/ecsx.gen.component_test.exs
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Ecsx.Gen.ComponentTest do
                  @moduledoc \"\"\"
                  ECSx manager.
                  \"\"\"
-                 use ECSx.Manager, tick_rate: 20
+                 use ECSx.Manager
 
                  setup do
                    # Load your initial components
@@ -101,7 +101,7 @@ defmodule Mix.Tasks.Ecsx.Gen.ComponentTest do
                  @moduledoc \"\"\"
                  ECSx manager.
                  \"\"\"
-                 use ECSx.Manager, tick_rate: 20
+                 use ECSx.Manager
 
                  setup do
                    # Load your initial components

--- a/test/mix/tasks/ecsx.gen.system_test.exs
+++ b/test/mix/tasks/ecsx.gen.system_test.exs
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Ecsx.Gen.SystemTest do
                  @moduledoc \"\"\"
                  ECSx manager.
                  \"\"\"
-                 use ECSx.Manager, tick_rate: 20
+                 use ECSx.Manager
 
                  setup do
                    # Load your initial components
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.Ecsx.Gen.SystemTest do
                  @moduledoc \"\"\"
                  ECSx manager.
                  \"\"\"
-                 use ECSx.Manager, tick_rate: 20
+                 use ECSx.Manager
 
                  setup do
                    # Load your initial components

--- a/test/mix/tasks/ecsx.gen.tag_test.exs
+++ b/test/mix/tasks/ecsx.gen.tag_test.exs
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Ecsx.Gen.TagTest do
                  @moduledoc \"\"\"
                  ECSx manager.
                  \"\"\"
-                 use ECSx.Manager, tick_rate: 20
+                 use ECSx.Manager
 
                  setup do
                    # Load your initial components
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Ecsx.Gen.TagTest do
                  @moduledoc \"\"\"
                  ECSx manager.
                  \"\"\"
-                 use ECSx.Manager, tick_rate: 20
+                 use ECSx.Manager
 
                  setup do
                    # Load your initial components

--- a/test/mix/tasks/ecsx.setup_test.exs
+++ b/test/mix/tasks/ecsx.setup_test.exs
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Ecsx.SetupTest do
                  @moduledoc \"\"\"
                  ECSx manager.
                  \"\"\"
-                 use ECSx.Manager, tick_rate: 20
+                 use ECSx.Manager
 
                  setup do
                    # Load your initial components


### PR DESCRIPTION
The live dashboard needs to know the tick rate and this makes sense to have configured globally