### PR TITLE
Manager config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-Adding ECSx.ClientEvents to the supervision tree is no longer required  
+Adding ECSx.ClientEvents to your supervision tree is no longer required  
+Adding the manager to your supervision tree is no longer required  
 Running a generator before ecsx.setup will now raise an error   
 Added telemetry events  
 Tick rate is now set in application config  
-Added ECSx.tick_rate/0 for reading the configured value  
+Manager module (and optional custom path) are now defined in application config  
+Added functions `tick_rate/0`, `manager/0`, and `manager_path/0` to the `ECSx` module for reading the configured values at runtime  
 
 ## v0.3.1 (2023-01-12)
 

--- a/README.md
+++ b/README.md
@@ -20,18 +20,6 @@ end
 
 * Run `mix deps.get`
 * Run `mix ecsx.setup`
-* Add the generated Manager module to your application's supervision tree:
-
-```elixir
-def start(_type, _args) do
-  children = [
-    MyApp.Manager
-  ]
-
-  opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-  Supervisor.start_link(children, opts)
-end
-```
 
 ## Tutorial Project
 

--- a/guides/Installation.md
+++ b/guides/Installation.md
@@ -56,19 +56,4 @@ With ECSx installed, you can run the setup generator:
 $ mix ecsx.setup
 ```
 
-which will create the Manager, and two folders to get your project started.
-
-You'll also need to add the Manager to your application's supervision tree:
-
-```elixir
-def start(_type, _args) do
-  children = [
-    MyApp.Manager
-  ]
-
-  opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-  Supervisor.start_link(children, opts)
-end
-```
-
-You should now have everything you need to start building!
+which will create the Manager, and two folders to get your project started.  You should now have everything you need to start building!

--- a/guides/tutorial/backend_basics.md
+++ b/guides/tutorial/backend_basics.md
@@ -354,14 +354,14 @@ end
 
 In this example we remove all the components the entity might have, then add a new DestroyedAt component with the current timestamp.  If we wanted some components to persist - such as the position and/or velocity, so the wreckage could still be visible on the player displays - we could keep them around and possibly have another system clean them up later on.  Likewise if there were other components to add, such as a `RespawnTimer` or `FinalScore`, we could add them here as well.
 
-## Initializing Components
+## Initializing Component Data
 
 By now you might be wondering "How did those components get created in the first place?"  We have code for adding `AttackCooldown` and `DestroyedAt`, when needed, but the basic components for the ships still need to be added before the game can even start.  For that, we'll check out `lib/ship/manager.ex`:
 
 ```elixir
 defmodule Ship.Manager do
   ...
-  use ECSx.Manager, tick_rate: 20
+  use ECSx.Manager
 
   setup do
     # Load your initial components
@@ -377,7 +377,7 @@ defmodule Ship.Manager do
 end
 ```
 
-This module holds four critical pieces of data - the server's tick rate, data initialization, a list of every valid component type, and a list of each game system in the order they are to be run.  Let's initialize some ship data inside the `setup` block:
+This module holds three critical pieces of data - component setup, a list of every valid component type, and a list of each game system in the order they are to be run.  Let's create some ship components inside the `setup` block:
 
 ```elixir
 setup do

--- a/guides/tutorial/initial_setup.md
+++ b/guides/tutorial/initial_setup.md
@@ -9,6 +9,5 @@ To demonstrate ECSx in a real-time application, we're going to make a game where
 * Add `{:ecsx, "~> 0.3"}` to your `mix.exs` deps
 * Run `mix deps.get`
 * Run `mix ecsx.setup`
-* Add `Ship.Manager` to your app's supervision tree
 
 

--- a/lib/mix/tasks/ecsx.gen.system.ex
+++ b/lib/mix/tasks/ecsx.gen.system.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.Ecsx.Gen.System do
   end
 
   defp inject_system_module_into_manager(system_name) do
-    manager_path = "lib/#{Helpers.otp_app()}/manager.ex"
+    manager_path = ECSx.manager_path()
     {before_systems, after_systems, list} = parse_manager(manager_path)
 
     new_list =

--- a/lib/mix/tasks/ecsx/helpers.ex
+++ b/lib/mix/tasks/ecsx/helpers.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.ECSx.Helpers do
   def write_file(contents, path), do: File.write!(path, contents)
 
   def inject_component_module_into_manager(component_type) do
-    manager_path = "lib/#{otp_app()}/manager.ex"
+    manager_path = ECSx.manager_path()
     {before_components, after_components, list} = parse_manager_components(manager_path)
 
     new_list =
@@ -74,8 +74,17 @@ defmodule Mix.Tasks.ECSx.Helpers do
 
   def read_manager_file!(path) do
     case File.read(path) do
-      {:ok, file} -> file
-      {:error, :enoent} -> Mix.raise("ECSx manager missing - please run `mix ecsx.setup` first!")
+      {:ok, file} ->
+        file
+
+      {:error, :enoent} ->
+        Mix.raise("""
+        ECSx manager missing - please run `mix ecsx.setup` first!
+        If you've already run the setup but moved or renamed your
+        manager file, you might need to configure the path:
+
+        config :ecsx, manager: {ManagerModule, path: "path/to/manager.ex"}
+        """)
     end
   end
 end

--- a/test/ecsx/ecsx_test.exs
+++ b/test/ecsx/ecsx_test.exs
@@ -1,3 +1,57 @@
 defmodule ECSxTest do
   use ExUnit.Case
+
+  describe "manager/0" do
+    test "standard module" do
+      Application.put_env(:ecsx, :manager, FooApp.BarManager)
+
+      assert ECSx.manager() == FooApp.BarManager
+    end
+
+    test "module with path" do
+      Application.put_env(:ecsx, :manager, {FooApp.BarManager, path: "foo/bar/baz.ex"})
+
+      assert ECSx.manager() == FooApp.BarManager
+    end
+
+    test "unconfigured" do
+      Application.delete_env(:ecsx, :manager)
+
+      assert ECSx.manager() == nil
+    end
+  end
+
+  describe "manager_path/0" do
+    test "standard module" do
+      Application.put_env(:ecsx, :manager, FooApp.BarManager)
+
+      assert ECSx.manager_path() == "lib/foo_app/bar_manager.ex"
+    end
+
+    test "module with path" do
+      Application.put_env(:ecsx, :manager, {FooApp.BarManager, path: "foo/bar/baz.ex"})
+
+      assert ECSx.manager_path() == "foo/bar/baz.ex"
+    end
+
+    test "unconfigured" do
+      Application.delete_env(:ecsx, :manager)
+
+      assert ECSx.manager_path() == nil
+    end
+  end
+
+  describe "tick_rate/0" do
+    test "fetches from app config" do
+      Application.put_env(:ecsx, :tick_rate, 101)
+
+      assert ECSx.tick_rate() == 101
+    end
+
+    test "defaults to 20 when unconfigured" do
+      Application.delete_env(:ecsx, :tick_rate)
+
+      assert ECSx.tick_rate() == 20
+    end
+  end
 end

--- a/test/mix/tasks/ecsx.setup_test.exs
+++ b/test/mix/tasks/ecsx.setup_test.exs
@@ -5,10 +5,13 @@ defmodule Mix.Tasks.Ecsx.SetupTest do
 
   import ECSx.MixHelper, only: [clean_tmp_dir: 0, sample_mixfile: 0]
 
+  @config_path "config/config.exs"
+
   setup do
     File.mkdir!("tmp")
     File.cd!("tmp")
     File.mkdir!("lib")
+    File.mkdir!("config")
     File.write!("mix.exs", sample_mixfile())
 
     on_exit(&clean_tmp_dir/0)
@@ -51,6 +54,160 @@ defmodule Mix.Tasks.Ecsx.SetupTest do
 
       assert File.dir?("lib/my_app/components")
       assert File.dir?("lib/my_app/systems")
+    end)
+  end
+
+  test "injects into basic config" do
+    Mix.Project.in_project(:my_app, ".", fn _module ->
+      File.write!(@config_path, "import Config\n")
+
+      Mix.Tasks.Ecsx.Setup.run([])
+
+      assert File.read!(@config_path) ==
+               """
+               import Config
+
+               config :ecsx,
+                 tick_rate: 20,
+                 manager: MyApp.Manager
+               """
+    end)
+  end
+
+  test "injects into missing config" do
+    Mix.Project.in_project(:my_app, ".", fn _module ->
+      Mix.Tasks.Ecsx.Setup.run([])
+
+      assert File.read!(@config_path) ==
+               """
+               import Config
+
+               config :ecsx,
+                 tick_rate: 20,
+                 manager: MyApp.Manager
+               """
+    end)
+  end
+
+  test "injects into realistic config" do
+    Mix.Project.in_project(:my_app, ".", fn _module ->
+      config = """
+      # This file is responsible for configuring your application
+      # and its dependencies with the aid of the Config module.
+      #
+      # This configuration file is loaded before any dependency and
+      # is restricted to this project.
+
+      # General application configuration
+      import Config
+
+      config :my_app,
+        ecto_repos: [MyApp.Repo]
+
+      # Configures the endpoint
+      config :my_app, MyAppWeb.Endpoint,
+        url: [host: "localhost"],
+        render_errors: [view: MyAppWeb.ErrorView, accepts: ~w(html json), layout: false],
+        pubsub_server: MyApp.PubSub,
+        live_view: [signing_salt: "foobar"]
+
+      # Configures the mailer
+      #
+      # By default it uses the "Local" adapter which stores the emails
+      # locally. You can see the emails in your browser, at "/dev/mailbox".
+      #
+      # For production it's recommended to configure a different adapter
+      # at the `config/runtime.exs`.
+      config :my_app, MyApp.Mailer, adapter: Swoosh.Adapters.Local
+
+      # Swoosh API client is needed for adapters other than SMTP.
+      config :swoosh, :api_client, false
+
+      # Configure esbuild (the version is required)
+      config :esbuild,
+      version: "0.14.41",
+      default: [
+      args:
+      ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
+      cd: Path.expand("../assets", __DIR__),
+      env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+      ]
+
+      # Configures Elixir's Logger
+      config :logger, :console,
+      format: "$time $metadata[$level] $message\n",
+      metadata: [:request_id]
+
+      # Use Jason for JSON parsing in Phoenix
+      config :phoenix, :json_library, Jason
+
+      # Import environment specific config. This must remain at the bottom
+      # of this file so it overrides the configuration defined above.
+      import_config "\#{config_env()}.exs"
+      """
+
+      File.write!(@config_path, config)
+
+      Mix.Tasks.Ecsx.Setup.run([])
+
+      assert File.read!(@config_path) == """
+             # This file is responsible for configuring your application
+             # and its dependencies with the aid of the Config module.
+             #
+             # This configuration file is loaded before any dependency and
+             # is restricted to this project.
+
+             # General application configuration
+             import Config
+
+             config :my_app,
+               ecto_repos: [MyApp.Repo]
+
+             # Configures the endpoint
+             config :my_app, MyAppWeb.Endpoint,
+               url: [host: "localhost"],
+               render_errors: [view: MyAppWeb.ErrorView, accepts: ~w(html json), layout: false],
+               pubsub_server: MyApp.PubSub,
+               live_view: [signing_salt: "foobar"]
+
+             # Configures the mailer
+             #
+             # By default it uses the "Local" adapter which stores the emails
+             # locally. You can see the emails in your browser, at "/dev/mailbox".
+             #
+             # For production it's recommended to configure a different adapter
+             # at the `config/runtime.exs`.
+             config :my_app, MyApp.Mailer, adapter: Swoosh.Adapters.Local
+
+             # Swoosh API client is needed for adapters other than SMTP.
+             config :swoosh, :api_client, false
+
+             # Configure esbuild (the version is required)
+             config :esbuild,
+             version: "0.14.41",
+             default: [
+             args:
+             ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
+             cd: Path.expand("../assets", __DIR__),
+             env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+             ]
+
+             # Configures Elixir's Logger
+             config :logger, :console,
+             format: "$time $metadata[$level] $message\n",
+             metadata: [:request_id]
+
+             # Use Jason for JSON parsing in Phoenix
+             config :phoenix, :json_library, Jason
+
+             config :ecsx,
+               tick_rate: 20,
+               manager: MyApp.Manager
+
+             # Import environment specific config. This must remain at the bottom
+             # of this file so it overrides the configuration defined above.
+             import_config "\#{config_env()}.exs"
+             """
     end)
   end
 

--- a/test/support/mix_helper.exs
+++ b/test/support/mix_helper.exs
@@ -38,6 +38,7 @@ defmodule ECSx.MixHelper do
     File.mkdir!("lib")
     File.mkdir!("lib/my_app")
     File.mkdir!("lib/my_app/components")
+    Application.put_env(:ecsx, :manager, MyApp.Manager)
     File.write!("mix.exs", @sample_mixfile)
 
     source = Application.app_dir(:ecsx, "/priv/templates/manager.ex")
@@ -55,6 +56,7 @@ defmodule ECSx.MixHelper do
   def clean_tmp_dir do
     File.cd!("..")
     File.rm_rf!("tmp")
+    Application.delete_env(:ecsx, :manager)
   end
 
   def sample_mixfile, do: @sample_mixfile


### PR DESCRIPTION
Manager module is now defined in the App config.  This will give other ECSx libraries - such as ecsx_live_dashboard - public access to to the module via new top-level helper `ECSx.manager/0`.  Another helper, `ECSx.manager_path/0` will infer the manager's filepath based on the module name.  Users can also provide a custom path in the app config.