### PR TITLE
Add more needed dependencies to tutorial

### DIFF
--- a/guides/tutorial/initial_setup.md
+++ b/guides/tutorial/initial_setup.md
@@ -7,6 +7,7 @@ To demonstrate ECSx in a real-time application, we're going to make a game where
 * First, ensure you have installed [Elixir](https://elixir-lang.org/install.html) and [Phoenix](https://hexdocs.pm/phoenix/installation.html).
 * Create the application by running `mix phx.new ship`
 * Add `{:ecsx, "~> 0.3"}` to your `mix.exs` deps
+* Add `{:ecto, "~> 3.9"}` to your `mix.exs` deps (for `Ecto.UUID.generate()`)
 * Run `mix deps.get`
 * Run `mix ecsx.setup`
 

--- a/guides/tutorial/initial_setup.md
+++ b/guides/tutorial/initial_setup.md
@@ -8,6 +8,7 @@ To demonstrate ECSx in a real-time application, we're going to make a game where
 * Create the application by running `mix phx.new ship`
 * Add `{:ecsx, "~> 0.3"}` to your `mix.exs` deps
 * Add `{:ecto, "~> 3.9"}` to your `mix.exs` deps (for `Ecto.UUID.generate()`)
+* Add `{:phoenix, "~> 1.7.2"}` and `{:phoenix_live_view, "~> 0.18.17"}` to your `mix.exs` deps (for our front end)
 * Run `mix deps.get`
 * Run `mix ecsx.setup`
 


### PR DESCRIPTION
In the tutorial, we use `Ecto.UUID.generate()` which isn't included so fails unless you add `:ecto` to the deps. We also use `mix phx.gen.auth` and Phoenix/LiveView.