### PR TITLE
Add `mix ecto.create` to the tutorial

### DIFF
--- a/guides/tutorial/initial_setup.md
+++ b/guides/tutorial/initial_setup.md
@@ -6,8 +6,7 @@ To demonstrate ECSx in a real-time application, we're going to make a game where
 
 * First, ensure you have installed [Elixir](https://elixir-lang.org/install.html) and [Phoenix](https://hexdocs.pm/phoenix/installation.html).
 * Create the application by running `mix phx.new ship`
+* Run `mix ecto.create` to initialize the database
 * Add `{:ecsx, "~> 0.3"}` to your `mix.exs` deps
 * Run `mix deps.get`
 * Run `mix ecsx.setup`
-
-


### PR DESCRIPTION
Later in the tutorial, we ask the user to run `mix ecto.migrate` which fails as we haven't had them run `mix ecto.create` first.