### PR TITLE
Swap Routes. helpers over to verified routes

### DIFF
--- a/guides/tutorial/initial_setup.md
+++ b/guides/tutorial/initial_setup.md
@@ -4,7 +4,7 @@ To demonstrate ECSx in a real-time application, we're going to make a game where
 
 > Note:  This guide will get you up-and-running with a working game, but it is intentionally generic.  Feel free to experiment with altering details from this implementation to customize your own game.
 
-* First, ensure you have installed [Elixir](https://elixir-lang.org/install.html) and [Phoenix](https://hexdocs.pm/phoenix/installation.html).
+* First, ensure you have installed [Elixir](https://elixir-lang.org/install.html) and [Phoenix](https://hexdocs.pm/phoenix/installation.html) 1.7+.
 * Create the application by running `mix phx.new ship`
 * Add `{:ecsx, "~> 0.3"}` to your `mix.exs` deps
 * Run `mix deps.get`

--- a/guides/tutorial/web_frontend_liveview.md
+++ b/guides/tutorial/web_frontend_liveview.md
@@ -327,7 +327,7 @@ defmodule ShipWeb.GameLive do
             y={@y_coord}
             width="1"
             height="1"
-            href={Routes.static_path(@socket, "/images/" <> @player_ship_image_file)}
+            href={~p"/images/#{@player_ship_image_file}"}
           />
           <%= for {_entity, x, y, image_file} <- @other_ships do %>
             <image
@@ -335,7 +335,7 @@ defmodule ShipWeb.GameLive do
               y={y}
               width="1"
               height="1"
-              href={Routes.static_path(@socket, "/images/" <> image_file)}
+              href={~p"/images/#{image_file}}
             />
           <% end %>
           <text x={@x_offset} y={@y_offset + 1} style="font: 1px serif">
@@ -502,7 +502,7 @@ defmodule Ship.Systems.ClientEventHandler do
 end
 ```
 
-Lastly, we'll need the [player_ship.svg](https://github.com/APB9785/ship/blob/master/priv/static/images/player_ship.svg) and [npc_ship.svg](https://github.com/APB9785/ship/blob/master/priv/static/images/npc_ship.svg) files.  Right-click on the links and save them to `priv/static/images/`, where they will be found by our `Routes.static_path/2` calls in the LiveView template.
+Lastly, we'll need the [player_ship.svg](https://github.com/APB9785/ship/blob/master/priv/static/images/player_ship.svg) and [npc_ship.svg](https://github.com/APB9785/ship/blob/master/priv/static/images/npc_ship.svg) files.  Right-click on the links and save them to `priv/static/images/`, where they will be found by our `~p"/images/..."` calls in the LiveView template.
 
 Now running
 
@@ -772,7 +772,7 @@ defmodule Ship.GameLive do
         y={y}
         width="1"
         height="1"
-        href={Routes.static_path(@socket, "/images/" <> image_file)}
+        href={~p"/images/#{image_file}"}
       />
     <% end %>
     ...


### PR DESCRIPTION
`Routes.xyz_path` won't work for anyone generating a fresh Phoenix 1.7 app, so we should use verified routes for the tutorial.