### PR TITLE
Update tutorial route for phoenix 1.7

### DIFF
--- a/guides/tutorial/web_frontend_liveview.md
+++ b/guides/tutorial/web_frontend_liveview.md
@@ -179,8 +179,11 @@ Head into `router.ex` and look for the new scope which uses `:require_authentica
 scope "/", ShipWeb do
   pipe_through [:browser, :require_authenticated_player]
 
-  live "/game", GameLive
-  ...
+  live_session :require_authenticated_player,
+    on_mount: [{ShipWeb.PlayerAuth, :ensure_authenticated}] do
+    live "/game", GameLive
+    ...
+  end
 end
 ```
 


### PR DESCRIPTION
Phoenix 1.7 changes authenticated scopes generated in the router, using `live_session` for more comprehensive auth in LiveViews.  This updates the ECSx LiveView tutorial to show the new scope format.

Resolves #33 